### PR TITLE
Changed regex for UE5.5

### DIFF
--- a/UnrealObjectPtrTool/Program.cs
+++ b/UnrealObjectPtrTool/Program.cs
@@ -44,7 +44,10 @@ namespace UnrealObjectPtrTool
 
             var pointersFound = new List<string>();
             var lines = File.ReadAllLines(FilePath);
-            var search = new Regex("Consider TObjectPtr as an alternative.");
+
+            // Change for UE5.5, since the log text contains a lowercase c at the beginning.
+            // Example: "Error: Native pointer usage in member declaration detected [[[class SomeType*]]].  This is disallowed for the target/module, consider TObjectPtr as an alternative."
+            var search = new Regex("[cC]onsider TObjectPtr as an alternative.");
 
             foreach (var line in lines)
             {


### PR DESCRIPTION
It seems that the UHT in UE5.5 uses a lowercase "c" in the string that is searched for by regex.

I have changed the regex and testet with both versions, should be working.